### PR TITLE
Fix preload in Chrome.

### DIFF
--- a/src/moment/unbundled.html
+++ b/src/moment/unbundled.html
@@ -12,7 +12,7 @@
   <div id="benchmark-results"></div>
   <div class="output"></div>
 
-  <script type="module" src="unbundled/app.js"></script>
+  <script type="module" src="unbundled/app.js" crossorigin='use-credentials'></script>
   <script type="module" src="../display-results.js"></script>
 </body>
 

--- a/src/three/unbundled.html
+++ b/src/three/unbundled.html
@@ -12,7 +12,7 @@
   <div id="benchmark-results"></div>
   <div class="output"></div>
 
-  <script type="module" src="unbundled/app.js"></script>
+  <script type="module" src="unbundled/app.js" crossorigin='use-credentials'></script>
   <script type="module" src="../display-results.js"></script>
 </body>
 


### PR DESCRIPTION
Without this change, the `crossorigin` attributes between the `<script>` and the `<link>` won't match, and the modules will be fetched twice.

Could you please take a look, @irori?

Thanks!